### PR TITLE
feat(config): support MINIMAX_BASE_URL override for custom endpoints

### DIFF
--- a/crates/hermes-agent/src/auxiliary_builder.rs
+++ b/crates/hermes-agent/src/auxiliary_builder.rs
@@ -136,14 +136,30 @@ pub fn build_default_auxiliary_client(
         "https://api.moonshot.ai/v1",
         default_models::KIMI,
     );
-    register_direct_key(
-        &mut builder,
-        &mut summary,
-        "MINIMAX_API_KEY",
-        "minimax",
-        "https://api.minimax.io/v1",
-        default_models::MINIMAX,
-    );
+    // MiniMax — supports MINIMAX_BASE_URL override (mirrors OPENAI_BASE_URL pattern)
+    if let Ok(key) = std::env::var("MINIMAX_API_KEY") {
+        if !key.trim().is_empty() {
+            let base_url = std::env::var("MINIMAX_BASE_URL")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| "https://api.minimax.io/v1".to_string());
+            let provider: Arc<dyn LlmProvider> = Arc::new(GenericProvider::new(
+                base_url,
+                key.trim(),
+                default_models::MINIMAX,
+            ));
+            builder = builder.add_candidate(ProviderCandidate::new(
+                AuxiliarySource::DirectKey("minimax".to_string()),
+                default_models::MINIMAX,
+                provider,
+            ));
+            summary.registered.push("minimax".into());
+        } else {
+            summary.skipped.push("minimax (empty key)".into());
+        }
+    } else {
+        summary.skipped.push("minimax (no key)".into());
+    }
     register_direct_key(
         &mut builder,
         &mut summary,

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -722,7 +722,13 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         "openrouter" => Arc::new(OpenRouterProvider::new(&api_key).with_model(model_name)),
         "qwen" => Arc::new(QwenProvider::new(&api_key).with_model(model_name)),
         "kimi" | "moonshot" => Arc::new(KimiProvider::new(&api_key).with_model(model_name)),
-        "minimax" => Arc::new(MiniMaxProvider::new(&api_key).with_model(model_name)),
+        "minimax" => {
+            let mut p = MiniMaxProvider::new(&api_key).with_model(model_name);
+            if let Some(url) = base_url {
+                p = p.with_base_url(url);
+            }
+            Arc::new(p)
+        }
         "nous" => Arc::new(NousProvider::new(&api_key).with_model(model_name)),
         "copilot" => Arc::new(
             CopilotProvider::new(


### PR DESCRIPTION
- Allow MINIMAX_BASE_URL env var to override the default MiniMax API endpoint, mirroring the OPENAI_BASE_URL pattern used by other providers
- Pass base_url through when constructing MiniMaxProvider in HTTP gateway