### PR TITLE
feat(gateway): add inbound channel routing and fix DmManager auth config

### DIFF
--- a/crates/hermes-cli/src/live_messaging.rs
+++ b/crates/hermes-cli/src/live_messaging.rs
@@ -500,17 +500,30 @@ async fn register_outbound_adapters(config: &GatewayConfig, gateway: &Arc<Gatewa
 
     if let Some(platform_cfg) = config.platforms.get("weixin") {
         if platform_cfg.enabled && !fatal_platforms.contains("weixin") {
-            let account_id = extra_string(platform_cfg, "account_id").unwrap_or_default();
-            let token = platform_token_or_extra(platform_cfg).unwrap_or_default();
-            if !account_id.is_empty() && !token.is_empty() {
-                let cfg = WeixinConfig::from_platform_config(platform_cfg);
-                match WeChatAdapter::new(cfg) {
-                    Ok(adapter) => {
-                        gateway.register_adapter("weixin", Arc::new(adapter)).await;
-                        registered.push("weixin".to_string());
-                    }
-                    Err(e) => tracing::warn!("weixin adapter init failed: {}", e),
+            let cfg = WeixinConfig::from_platform_config(platform_cfg);
+            match WeChatAdapter::new(cfg) {
+                Ok(adapter) => {
+                    let adapter = Arc::new(adapter);
+                    let (inbound_tx, mut inbound_rx) =
+                        tokio::sync::mpsc::channel::<hermes_gateway::gateway::IncomingMessage>(256);
+                    adapter.set_inbound_sender(inbound_tx).await;
+                    let gw_clone = gateway.clone();
+                    tokio::spawn(async move {
+                        while let Some(msg) = inbound_rx.recv().await {
+                            if let Err(e) = gw_clone.route_message(&msg).await {
+                                tracing::warn!(
+                                    platform = %msg.platform,
+                                    chat_id = %msg.chat_id,
+                                    error = %e,
+                                    "weixin inbound routing failed"
+                                );
+                            }
+                        }
+                    });
+                    gateway.register_adapter("weixin", adapter).await;
+                    registered.push("weixin".to_string());
                 }
+                Err(e) => tracing::warn!("weixin adapter init failed: {}", e),
             }
         }
     }

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -13,7 +13,7 @@ use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, error, info, warn};
 
 use hermes_core::errors::GatewayError;
@@ -194,13 +194,30 @@ struct SessionRuntimeState {
 // Gateway
 // ---------------------------------------------------------------------------
 
+/// Background task that reads inbound messages from `rx` and routes them
+/// through the gateway's full pipeline (DM check → session → agent → reply).
+async fn gw_pump_inbound(gateway: Arc<Gateway>, mut rx: mpsc::Receiver<IncomingMessage>) {
+    while let Some(msg) = rx.recv().await {
+        if let Err(e) = gateway.route_message(&msg).await {
+            warn!(
+                platform = %msg.platform,
+                chat_id = %msg.chat_id,
+                user_id = %msg.user_id,
+                error = %e,
+                "inbound message routing failed"
+            );
+        }
+    }
+    debug!("inbound pump exited");
+}
+
 /// Central orchestrator for all platform adapters.
 ///
 /// The `Gateway` owns a collection of named `PlatformAdapter` instances,
 /// a `SessionManager`, a `DmManager`, and a `StreamManager`. It provides
 /// a unified interface to start/stop adapters and route messages.
 pub struct Gateway {
-    adapters: RwLock<HashMap<String, Arc<dyn PlatformAdapter>>>,
+    adapters: Arc<RwLock<HashMap<String, Arc<dyn PlatformAdapter>>>>,
     session_manager: Arc<SessionManager>,
     dm_manager: Arc<RwLock<DmManager>>,
     stream_manager: Arc<StreamManager>,
@@ -235,7 +252,7 @@ impl Gateway {
         let stream_manager = Arc::new(StreamManager::new(config.streaming.clone()));
 
         Self {
-            adapters: RwLock::new(HashMap::new()),
+            adapters: Arc::new(RwLock::new(HashMap::new())),
             session_manager,
             dm_manager: Arc::new(RwLock::new(dm_manager)),
             stream_manager,
@@ -346,6 +363,31 @@ impl Gateway {
         let name = name.into();
         info!("Registering platform adapter: {}", name);
         self.adapters.write().await.insert(name, adapter);
+    }
+
+    /// Register a platform adapter and spawn a background task that reads
+    /// inbound messages from `rx` and routes them through [`Self::route_message`].
+    ///
+    /// Polling-based adapters (weixin, dingtalk, webhook) produce inbound
+    /// messages on an `mpsc::Sender`.  Pass the corresponding `Receiver` here
+    /// so the gateway can deliver them to the agent loop.
+    ///
+    /// Requires `Arc<Self>` because the spawned pump task must hold a strong
+    /// reference to the gateway.
+    pub fn register_adapter_with_inbound(
+        self: &Arc<Self>,
+        name: impl Into<String>,
+        adapter: Arc<dyn PlatformAdapter>,
+        rx: mpsc::Receiver<IncomingMessage>,
+    ) -> tokio::task::JoinHandle<()> {
+        let name = name.into();
+        info!("Registering platform adapter (inbound): {}", name);
+        let gw = self.clone();
+        let adapters = self.adapters.clone();
+        tokio::spawn(async move {
+            adapters.write().await.insert(name, adapter);
+            gw_pump_inbound(gw, rx).await;
+        })
     }
 
     /// Retrieve a registered platform adapter by name.

--- a/crates/hermes-gateway/src/platform_registry.rs
+++ b/crates/hermes-gateway/src/platform_registry.rs
@@ -49,7 +49,7 @@ pub struct RegistrationSummary {
 /// This function registers all enabled platform adapters from the configuration
 /// into the gateway. It supports all 17 platform adapters + ApiServer + Webhook.
 pub async fn register_platforms(
-    gateway: &Gateway,
+    gateway: &Arc<Gateway>,
     config: &GatewayConfig,
     sidecar_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
 ) -> Result<RegistrationSummary, AgentError> {
@@ -179,7 +179,12 @@ pub async fn register_platforms(
                     let wx_cfg = WeixinConfig::from_platform_config(platform_cfg);
                     match WeChatAdapter::new(wx_cfg) {
                         Ok(adapter) => {
-                            gateway.register_adapter("weixin", Arc::new(adapter)).await;
+                            let adapter = Arc::new(adapter);
+                            let (inbound_tx, inbound_rx) =
+                                tokio::sync::mpsc::channel::<crate::gateway::IncomingMessage>(256);
+                            adapter.set_inbound_sender(inbound_tx).await;
+                            gateway
+                                .register_adapter_with_inbound("weixin", adapter.clone(), inbound_rx);
                             registered.push("weixin".to_string());
                         }
                         Err(e) => errors.push(("weixin".to_string(), e.to_string())),

--- a/crates/hermes-runtime/src/lib.rs
+++ b/crates/hermes-runtime/src/lib.rs
@@ -193,7 +193,34 @@ impl RuntimeBuilder {
                 ..RuntimeGatewayConfig::default()
             };
             let session_manager = Arc::new(SessionManager::new(config.session.clone()));
-            let dm_manager = DmManager::with_pair_behavior();
+
+            // Collect allowed_users / admin_users from all platform configs
+            // and feed them into the DmManager so the gateway's auth gate
+            // actually recognises users listed in config.yaml.
+            let mut authorized_users = std::collections::HashSet::new();
+            let mut admin_users = std::collections::HashSet::new();
+            let mut any_pair = false;
+            for (_name, plat_cfg) in &config.platforms {
+                for u in &plat_cfg.allowed_users {
+                    authorized_users.insert(u.clone());
+                }
+                for u in &plat_cfg.admin_users {
+                    admin_users.insert(u.clone());
+                }
+                if plat_cfg.unauthorized_dm_behavior == hermes_config::UnauthorizedDmBehavior::Pair {
+                    any_pair = true;
+                }
+            }
+            let unauthorized_behavior = if any_pair {
+                hermes_config::UnauthorizedDmBehavior::Pair
+            } else {
+                hermes_config::UnauthorizedDmBehavior::Ignore
+            };
+            let dm_manager = DmManager::new(
+                authorized_users,
+                admin_users,
+                unauthorized_behavior,
+            );
             let gw = Arc::new(Gateway::new(
                 session_manager,
                 dm_manager,


### PR DESCRIPTION
Add `register_adapter_with_inbound` to Gateway so polling-based adapters (weixin, dingtalk, webhook) can deliver inbound messages through a dedicated mpsc channel instead of requiring direct adapter access to route_message.

Wrap the adapters map in Arc<RwLock<…>> so the spawned pump task can hold a strong reference to the gateway.

Wire up the weixin adapter to use the new inbound channel in both platform_registry and live_messaging.

Build DmManager from actual allowed_users/admin_users in config rather than the default empty set, so the gateway auth gate recognises configured users.